### PR TITLE
fix incorrect reference to "example" cloudwatch_log_group

### DIFF
--- a/aws_cloudtrail.tf
+++ b/aws_cloudtrail.tf
@@ -43,7 +43,7 @@ resource "aws_cloudtrail" "ct" {
   enable_log_file_validation    = var.aws_flags.enable_log_file_validation
   include_global_service_events = var.aws_flags.include_global_service_events
   is_multi_region_trail         = var.aws_flags.is_multi_region_trail
-  cloud_watch_logs_group_arn    = "${replace(aws_cloudwatch_log_group.example.arn, "/:\\*$/", "")}:*"
+  cloud_watch_logs_group_arn    = "${replace(aws_cloudwatch_log_group.ct.arn, "/:\\*$/", "")}:*"
   cloud_watch_logs_role_arn     = aws_iam_role.ct.arn
   sns_topic_name                = aws_sns_topic.sns.arn
   depends_on                    = [aws_s3_bucket_policy.bucket]


### PR DESCRIPTION
There is an accidental reference to an "example" resource.  This fixes it to use the correctly named "ct" resource.