### PR TITLE
Remove Template Dependency

### DIFF
--- a/aws_cloudtrail.tf
+++ b/aws_cloudtrail.tf
@@ -1,17 +1,13 @@
 // AWS Cloudtrail
-data "template_file" "aws_iam_cloudtrail_to_cloudwatch_assume_role_policy" {
-  template = file(
-    "${path.module}/aws_iam_cloudtrail_to_cloudwatch_assume_role_policy.tpl",
-  )
-}
 
-data "template_file" "aws_iam_cloudtrail_to_cloudwatch_policy" {
-  template = file("${path.module}/aws_iam_cloudtrail_to_cloudwatch_policy.tpl")
-  vars = {
+locals {
+  aws_iam_cloudtrail_to_cloudwatch_assume_role_policy = file("${path.module}/aws_iam_cloudtrail_to_cloudwatch_assume_role_policy.tpl")
+  aws_iam_cloudtrail_to_cloudwatch_policy_vars = {
     aws_account_id      = var.aws_account_info.account_id
     aws_cloudtrail_name = var.aws_optional_conf.cloudtrail_name
     aws_region          = var.aws_account_info.region
   }
+  aws_iam_cloudtrail_to_cloudwatch_policy = templatefile("${path.module}/aws_iam_cloudtrail_to_cloudwatch_policy.tpl", local.aws_iam_cloudtrail_to_cloudwatch_policy_vars)
 }
 
 resource "aws_cloudwatch_log_group" "ct" {
@@ -29,10 +25,10 @@ resource "aws_cloudwatch_log_group" "ct" {
 resource "aws_iam_role" "ct" {
   count = var.existing_cloudtrail != null ? 0 : 1 # Don't create this if using an existing cloudtrail
 
-  name               = "${var.aws_optional_conf.cloudtrail_name}-CloudTrailToCloudWatch"
-  tags               = var.aws_optional_conf.tags
+  name = "${var.aws_optional_conf.cloudtrail_name}-CloudTrailToCloudWatch"
+  tags = var.aws_optional_conf.tags
 
-  assume_role_policy = data.template_file.aws_iam_cloudtrail_to_cloudwatch_assume_role_policy.rendered
+  assume_role_policy = local.aws_iam_cloudtrail_to_cloudwatch_assume_role_policy
 }
 
 resource "aws_iam_role_policy" "ct" {
@@ -40,14 +36,14 @@ resource "aws_iam_role_policy" "ct" {
 
   name   = "CloudTrailToCloudWatch"
   role   = aws_iam_role.ct[0].id
-  policy = data.template_file.aws_iam_cloudtrail_to_cloudwatch_policy.rendered
+  policy = local.aws_iam_cloudtrail_to_cloudwatch_policy
 }
 
 resource "aws_cloudtrail" "ct" {
   count = var.existing_cloudtrail != null ? 0 : 1 # Don't create this if using an existing cloudtrail
 
-  name                          = var.aws_optional_conf.cloudtrail_name
-  tags                          = var.aws_optional_conf.tags
+  name = var.aws_optional_conf.cloudtrail_name
+  tags = var.aws_optional_conf.tags
 
   s3_bucket_name                = aws_s3_bucket.bucket[0].id
   enable_logging                = var.aws_flags.enable_logging

--- a/aws_iam_role.tf
+++ b/aws_iam_role.tf
@@ -1,36 +1,33 @@
 // AWS Iam role for cross account access
 
-data "template_file" "aws_iam_assume_role_policy" {
-  template = file("${path.module}/aws_iam_assume_role_policy.tpl")
-  vars = {
+locals {
+  aws_iam_assume_role_policy_vars = {
     threatstack_account_id  = var.threatstack.account_id
     threatstack_external_id = var.threatstack.external_id
   }
-}
+  aws_iam_assume_role_policy = templatefile("${path.module}/aws_iam_assume_role_policy.tpl", local.aws_iam_assume_role_policy_vars)
 
-data "template_file" "aws_iam_role_policy" {
-  template = file("${path.module}/aws_iam_role_policy.tpl")
-  vars = {
+  aws_iam_role_policy_vars = {
     sqs_queue_arn = aws_sqs_queue.sqs.arn
 
     # This checks to see if a new bucket exists (null check)
     # If it is null, just give a null so coalesce skips it
     # If not null, return the arn of the bucket, which is what we really need
-    s3_resource   = coalesce((length(aws_s3_bucket.bucket) > 0 ? aws_s3_bucket.bucket[0].arn : ""), (var.existing_cloudtrail != null ? var.existing_cloudtrail.s3_bucket_arn : ""))
+    s3_resource = coalesce((length(aws_s3_bucket.bucket) > 0 ? aws_s3_bucket.bucket[0].arn : ""), (var.existing_cloudtrail != null ? var.existing_cloudtrail.s3_bucket_arn : ""))
   }
+  aws_iam_role_policy = templatefile("${path.module}/aws_iam_role_policy.tpl", local.aws_iam_role_policy_vars)
 }
-
 resource "aws_iam_role" "role" {
-  name               = var.aws_optional_conf.iam_role_name
-  tags               = var.aws_optional_conf.tags
+  name = var.aws_optional_conf.iam_role_name
+  tags = var.aws_optional_conf.tags
 
-  assume_role_policy = data.template_file.aws_iam_assume_role_policy.rendered
+  assume_role_policy = local.aws_iam_assume_role_policy
 }
 
 resource "aws_iam_role_policy" "role" {
   name = var.aws_optional_conf.iam_role_name
   role = aws_iam_role.role.id
 
-  policy = data.template_file.aws_iam_role_policy.rendered
+  policy = local.aws_iam_role_policy
 }
 

--- a/aws_s3_bucket.tf
+++ b/aws_s3_bucket.tf
@@ -1,13 +1,11 @@
 // AWS CloudTrail S3 Bucket
-data "template_file" "aws_s3_bucket_policy" {
-  count = var.existing_cloudtrail != null ? 0 : 1 # Don't create this if using an existing cloudtrail
 
-  template = file("${path.module}/aws_s3_bucket_policy.tpl")
-
-  vars = {
+locals {
+  aws_s3_bucket_policy_vars = {
     aws_account_id = var.aws_account_info.account_id
     s3_bucket_arn  = aws_s3_bucket.bucket[0].arn
   }
+  aws_s3_bucket_policy = templatefile("${path.module}/aws_s3_bucket_policy.tpl", local.aws_s3_bucket_policy_vars)
 }
 
 resource "aws_s3_bucket" "bucket" {
@@ -23,15 +21,15 @@ resource "aws_s3_bucket" "bucket" {
   }
   force_destroy = var.aws_flags.s3_force_destroy
 
-  tags          = var.aws_optional_conf.tags
+  tags = var.aws_optional_conf.tags
 
-  depends_on    = [aws_sns_topic_subscription.sqs]
+  depends_on = [aws_sns_topic_subscription.sqs]
 }
 
 resource "aws_s3_bucket_policy" "bucket" {
   count = var.existing_cloudtrail != null ? 0 : 1 # Don't create this if using an existing cloudtrail
 
   bucket = aws_s3_bucket.bucket[0].id
-  policy = data.template_file.aws_s3_bucket_policy[0].rendered
+  policy = local.aws_s3_bucket_policy
 }
 

--- a/aws_sns_topic.tf
+++ b/aws_sns_topic.tf
@@ -1,12 +1,12 @@
 // SNS topic
 
-data "template_file" "aws_sns_topic_policy" {
-  template = file("${path.module}/aws_sns_topic_policy.tpl")
+locals {
+  aws_sns_topic_policy = file("${path.module}/aws_sns_topic_policy.tpl")
 }
 
 resource "aws_sns_topic" "sns" {
-  name         = var.aws_optional_conf.sns_topic_name
-  tags         = var.aws_optional_conf.tags
+  name = var.aws_optional_conf.sns_topic_name
+  tags = var.aws_optional_conf.tags
 
   display_name = var.aws_optional_conf.sns_topic_display_name
   depends_on   = [aws_iam_role.role]
@@ -14,6 +14,6 @@ resource "aws_sns_topic" "sns" {
 
 resource "aws_sns_topic_policy" "sns" {
   arn    = aws_sns_topic.sns.arn
-  policy = data.template_file.aws_sns_topic_policy.rendered
+  policy = local.aws_sns_topic_policy
 }
 

--- a/aws_sqs_queue.tf
+++ b/aws_sqs_queue.tf
@@ -1,22 +1,22 @@
 // Setup SQS
 
-data "template_file" "aws_sqs_queue_policy" {
-  template = file("${path.module}/aws_sqs_queue_policy.tpl")
-  vars = {
+locals {
+  aws_sqs_queue_policy_vars = {
     sns_arn = aws_sns_topic.sns.arn
   }
+  aws_sqs_queue_policy = templatefile("${path.module}/aws_sqs_queue_policy.tpl", local.aws_sqs_queue_policy_vars)
 }
 
 resource "aws_sqs_queue" "sqs" {
-  name       = var.aws_optional_conf.sqs_queue_name
-  tags       = var.aws_optional_conf.tags
+  name = var.aws_optional_conf.sqs_queue_name
+  tags = var.aws_optional_conf.tags
 
   depends_on = [aws_sns_topic_policy.sns]
 }
 
 resource "aws_sqs_queue_policy" "sqs" {
   queue_url = aws_sqs_queue.sqs.id
-  policy    = data.template_file.aws_sqs_queue_policy.rendered
+  policy    = local.aws_sqs_queue_policy
 }
 
 resource "aws_sns_topic_subscription" "sqs" {

--- a/module_provider_constraints.tf
+++ b/module_provider_constraints.tf
@@ -1,6 +1,5 @@
 terraform {
   required_providers {
-    aws      = ">= 2.0"
-    template = "~> 2.1"
+    aws = ">= 2.0, < 4.0.0"
   }
 }


### PR DESCRIPTION
- Removes Deprecated provider [template](https://registry.terraform.io/providers/hashicorp/template/latest), replaces with [templatefile](https://www.terraform.io/language/functions/templatefile) introduced in [Terraform v0.12.0](https://github.com/hashicorp/terraform/releases/tag/v0.12.0)
- Updates AWS Provider constraint to `>= 2.0, < 4.0.0` due to breaking changes introduced in [AWS Provider v4.0.0](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v4.0.0) and the `aws_s3_bucket` resource.

This change maintains compatibility with Terraform 0.12+. This change does not change generated resources, variables, or outputs.

This change is needed due to the template provider not being compatible with my system (darwin_arm64).